### PR TITLE
Add initial audit progress board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# audit_tracker
-audit tracker for audit team
+# Audit Tracker
+
+A lightweight, modern Kanban-style dashboard for monitoring audit progress across clients. The board presents clients down the left-hand side and three workflow stages across the top: Fieldwork, Manager Review, and Partner Review. Each cell lets you quickly mark the current status for that client-stage combination—Not started, In progress, Complete, or Waiting on client—with colours that surface at-risk engagements at a glance.
+
+## Getting started
+
+1. Open the `index.html` file in your browser.
+2. Use the status dropdowns to track each client's progress through the audit workflow.
+
+The board is responsive and adapts to smaller screens by stacking the columns vertically.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Audit Progress Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="branding">
+      <div class="logo-circle">AT</div>
+      <div>
+        <h1>Audit Tracker</h1>
+        <p>Monitor audit progress across the portfolio at a glance.</p>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="board" aria-label="Audit progress board">
+      <div class="board-columns">
+        <div class="board-column board-column--clients">
+          <div class="board-column__header">Client</div>
+          <div class="board-column__body" id="client-list"></div>
+        </div>
+        <div class="board-column" data-stage="fieldwork">
+          <div class="board-column__header">Fieldwork</div>
+          <div class="board-column__body" id="fieldwork-column"></div>
+        </div>
+        <div class="board-column" data-stage="managerReview">
+          <div class="board-column__header">Manager Review</div>
+          <div class="board-column__body" id="manager-column"></div>
+        </div>
+        <div class="board-column" data-stage="partnerReview">
+          <div class="board-column__header">Partner Review</div>
+          <div class="board-column__body" id="partner-column"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <template id="status-cell-template">
+    <div class="status-cell">
+      <select class="status-select" aria-label="Select audit status">
+        <option value="notStarted">Not started</option>
+        <option value="inProgress">In progress</option>
+        <option value="complete">Complete</option>
+        <option value="waiting">Waiting on client</option>
+      </select>
+    </div>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,104 @@
+const clients = [
+  {
+    name: 'Acme Manufacturing Ltd',
+    statuses: {
+      fieldwork: 'inProgress',
+      managerReview: 'notStarted',
+      partnerReview: 'notStarted'
+    }
+  },
+  {
+    name: 'Brighton Hospitality Group',
+    statuses: {
+      fieldwork: 'waiting',
+      managerReview: 'notStarted',
+      partnerReview: 'notStarted'
+    }
+  },
+  {
+    name: 'Cambridge BioTech PLC',
+    statuses: {
+      fieldwork: 'complete',
+      managerReview: 'inProgress',
+      partnerReview: 'notStarted'
+    }
+  },
+  {
+    name: 'Devonshire Retail Co.',
+    statuses: {
+      fieldwork: 'complete',
+      managerReview: 'complete',
+      partnerReview: 'inProgress'
+    }
+  },
+  {
+    name: 'Evergreen Services LLP',
+    statuses: {
+      fieldwork: 'notStarted',
+      managerReview: 'notStarted',
+      partnerReview: 'notStarted'
+    }
+  }
+];
+
+const stages = [
+  { id: 'fieldwork', label: 'Fieldwork' },
+  { id: 'managerReview', label: 'Manager Review' },
+  { id: 'partnerReview', label: 'Partner Review' }
+];
+
+function createClientList(container) {
+  clients.forEach((client) => {
+    const card = document.createElement('div');
+    card.className = 'client-name';
+    card.textContent = client.name;
+    card.setAttribute('role', 'rowheader');
+    container.appendChild(card);
+  });
+}
+
+function createStatusCells() {
+  const template = document.getElementById('status-cell-template');
+
+  stages.forEach((stage) => {
+    const column = document.querySelector(`[data-stage="${stage.id}"] .board-column__body`);
+
+    clients.forEach((client) => {
+      const statusCell = template.content.firstElementChild.cloneNode(true);
+      const select = statusCell.querySelector('.status-select');
+      const statusValue = client.statuses[stage.id] ?? 'notStarted';
+
+      select.value = statusValue;
+      updateStatusAppearance(statusCell, statusValue);
+
+      select.addEventListener('change', (event) => {
+        const value = event.target.value;
+        updateStatusAppearance(statusCell, value);
+        client.statuses[stage.id] = value;
+      });
+
+      column.appendChild(statusCell);
+    });
+  });
+}
+
+function updateStatusAppearance(cell, value) {
+  const validStatuses = ['notStarted', 'inProgress', 'complete', 'waiting'];
+  if (!validStatuses.includes(value)) {
+    value = 'notStarted';
+  }
+
+  if (value === 'notStarted') {
+    cell.removeAttribute('data-status');
+  } else {
+    cell.dataset.status = value;
+  }
+}
+
+function initBoard() {
+  const clientListContainer = document.getElementById('client-list');
+  createClientList(clientListContainer);
+  createStatusCells();
+}
+
+window.addEventListener('DOMContentLoaded', initBoard);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,210 @@
+:root {
+  --color-bg: #f6f7fb;
+  --color-surface: #ffffff;
+  --color-border: #e1e4eb;
+  --color-text: #1f2933;
+  --color-muted: #627084;
+  --color-accent: #3f8cff;
+  --color-select-border: #c7d2e1;
+
+  --status-not-started: transparent;
+  --status-in-progress: #f8e08e;
+  --status-complete: #a3d9a5;
+  --status-waiting: #f8b4b4;
+
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(180deg, rgba(63, 140, 255, 0.1), rgba(63, 140, 255, 0) 40%),
+    var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 2.5rem 3rem 1rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.logo-circle {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: var(--color-surface);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.branding h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.75rem;
+}
+
+.branding p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+main {
+  padding: 0 3rem 3rem;
+}
+
+.board {
+  background: var(--color-surface);
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 45px -24px rgba(15, 23, 42, 0.25);
+  padding: 2rem;
+}
+
+.board-columns {
+  display: grid;
+  grid-template-columns: 1.2fr repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.board-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.board-column__header {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  color: var(--color-muted);
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 0.75rem;
+}
+
+.board-column__body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.board-column--clients .board-column__body {
+  align-content: start;
+}
+
+.client-name {
+  background: rgba(63, 140, 255, 0.08);
+  color: var(--color-accent);
+  font-weight: 600;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(63, 140, 255, 0.12);
+}
+
+.status-cell {
+  background: rgba(98, 112, 132, 0.05);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(98, 112, 132, 0.15);
+  padding: 0.75rem;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 3.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.status-cell[data-status='inProgress'] {
+  background: var(--status-in-progress);
+  border-color: rgba(227, 171, 30, 0.6);
+}
+
+.status-cell[data-status='complete'] {
+  background: var(--status-complete);
+  border-color: rgba(58, 162, 92, 0.6);
+}
+
+.status-cell[data-status='waiting'] {
+  background: var(--status-waiting);
+  border-color: rgba(217, 87, 87, 0.6);
+}
+
+.status-select {
+  width: 100%;
+  border: 1px solid var(--color-select-border);
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: var(--color-text);
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--color-muted) 50%),
+    linear-gradient(135deg, var(--color-muted) 50%, transparent 50%),
+    linear-gradient(to right, transparent, transparent);
+  background-position: calc(100% - 18px) calc(50% - 3px),
+    calc(100% - 13px) calc(50% - 3px),
+    calc(100% - 2.5rem) 50%;
+  background-size: 6px 6px, 6px 6px, 1px 2.5rem;
+  background-repeat: no-repeat;
+}
+
+.status-select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(63, 140, 255, 0.15);
+}
+
+@media (max-width: 1024px) {
+  main {
+    padding: 0 1.5rem 2rem;
+  }
+
+  .board {
+    padding: 1.5rem;
+  }
+
+  .board-columns {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    background: var(--color-bg);
+  }
+
+  .app-header {
+    padding: 2rem 1.5rem 1rem;
+  }
+
+  main {
+    padding: 0 1rem 2rem;
+  }
+
+  .board-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .board-column__header {
+    margin-bottom: 0.5rem;
+  }
+
+  .board-column__body {
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+
+  .board-column--clients .board-column__body {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static Kanban board interface to visualise client audit progress
- style the layout with a modern responsive design and status colour coding
- provide starter client data with interactive status dropdowns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0bda1ce84832b88f85b38450a793c